### PR TITLE
external_port is an integer

### DIFF
--- a/lxd-dashboard/backend/config/db.php
+++ b/lxd-dashboard/backend/config/db.php
@@ -479,7 +479,7 @@ function addHost($host, $port, $alias, $external_host, $external_port){
   $stmt->bindValue(':port', $port, PDO::PARAM_INT);
   $stmt->bindValue(':alias', $alias, PDO::PARAM_STR);
   $stmt->bindValue(':external_host', $external_host, PDO::PARAM_STR);
-  $stmt->bindValue(':external_port', $external_port, PDO::PARAM_STR);
+  $stmt->bindValue(':external_port', $external_port, PDO::PARAM_INT);
   $stmt->bindValue(':user_id', $_SESSION['user_id'], PDO::PARAM_INT);
   $stmt->execute();
   $db = null;
@@ -933,7 +933,7 @@ function updateHost($id, $host, $port, $alias, $external_host, $external_port){
   $stmt->bindValue(':port', $port, PDO::PARAM_INT);
   $stmt->bindValue(':alias', $alias, PDO::PARAM_STR);
   $stmt->bindValue(':external_host', $external_host, PDO::PARAM_STR);
-  $stmt->bindValue(':external_port', $external_port, PDO::PARAM_STR);
+  $stmt->bindValue(':external_port', $external_port, PDO::PARAM_INT);
   $stmt->execute();
   $db = null;
   return $stmt;


### PR DESCRIPTION
Adding or updating an host do nothing. When I print the error `$stmt->errorInfo()` with `error_log(print_r($stmt->errorInfo(), true));` I have the message: 
> FastCGI sent in stderr: "PHP message: Array
(
    [0] => 22007
    [1] => 1366
    [2] => Incorrect integer value: '' for column `lxd_dashboard`.`lxd_hosts`.`external_port` at row 1
)"
