### PR TITLE
Cloud-init support for LXC containers

### DIFF
--- a/lxd-dashboard/backend/lxd/containers.php
+++ b/lxd-dashboard/backend/lxd/containers.php
@@ -52,6 +52,7 @@ if (isset($_SESSION['username'])) {
   $boot_autostart_priority = (isset($_GET['boot_autostart_priority'])) ? filter_var(urldecode($_GET['boot_autostart_priority']), FILTER_SANITIZE_STRING) : "";
   $boot_host_shutdown_timeout = (isset($_GET['boot_host_shutdown_timeout'])) ? filter_var(urldecode($_GET['boot_host_shutdown_timeout']), FILTER_SANITIZE_STRING) : "";
   $boot_stop_priority = (isset($_GET['boot_stop_priority'])) ? filter_var(urldecode($_GET['boot_stop_priority']), FILTER_SANITIZE_STRING) : "";
+  $cloud_init_user_data = (isset($_GET['cloud_init_user_data'])) ? filter_var(urldecode($_GET['cloud_init_user_data']), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES) : "";
   $limits_cpu = (isset($_GET['limits_cpu'])) ? filter_var(urldecode($_GET['limits_cpu']), FILTER_SANITIZE_STRING) : "";
   $limits_cpu_allowance = (isset($_GET['limits_cpu_allowance'])) ? filter_var(urldecode($_GET['limits_cpu_allowance']), FILTER_SANITIZE_STRING) : "";
   $limits_cpu_priority = (isset($_GET['limits_cpu_priority'])) ? filter_var(urldecode($_GET['limits_cpu_priority']), FILTER_SANITIZE_STRING) : "";
@@ -285,6 +286,8 @@ if (isset($_SESSION['username'])) {
       if (!empty($boot_autostart_priority)){ $instance_array['config']['boot.autostart.priority'] = $boot_autostart_priority;}
       if (!empty($boot_host_shutdown_timeout)){ $instance_array['config']['boot.host_shutdown_timeout'] = $boot_host_shutdown_timeout;}
       if (!empty($boot_stop_priority)){ $instance_array['config']['boot.stop.priority'] = $boot_stop_priority;}
+
+      if (!empty($cloud_init_user_data)){ $instance_array['config']['cloud-init.user-data'] = $cloud_init_user_data;}
 
       if (!empty($limits_cpu)){ $instance_array['config']['limits.cpu'] = $limits_cpu;}
       if (!empty($limits_cpu_allowance)){ $instance_array['config']['limits.cpu.allowance'] = $limits_cpu_allowance;}

--- a/lxd-dashboard/containers-single.php
+++ b/lxd-dashboard/containers-single.php
@@ -607,6 +607,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                               </div>
                               </div>
                               <!-- End Security Syscalls Card -->
+
+                              <!-- Cloud-Init Card -->
+                              <div class="card col-12 border-0 mb-2">
+                              <!-- Card Header - Dropdown -->
+                              <div class="card-header border-0 bg-transparent py-1 d-flex flex-row align-items-center justify-content-between">
+                                <h5 class="m-0 font-weight-bold text-primary">Cloud-Init</h5>
+                              </div>
+                              <!-- Card Body -->
+                              <div class="card-body pt-1">
+                                <div class="row">
+                                  <div class="col-12">
+                                    <table class="table table-sm">
+                                      <tr><td class="pr-3 font-weight-bold">User-Data:</td> <td><span id="cloudInitUserData"></span></td></tr>
+                                    </table>
+                                  </div>
+                                </div>
+                              </div>
+                              </div>
+                              <!-- End Security Syscalls Card -->
                           </div>
                         </div>
                         <!-- End Config List -->
@@ -3717,6 +3736,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           if (dataConfig.hasOwnProperty('boot.autostart.priority')) { $("#bootAutostartPriority").text(dataConfig['boot.autostart.priority']); } else { $("#bootAutostartPriority").text(""); }
           if (dataConfig.hasOwnProperty('boot.host_shutdown_timeout')) { $("#bootHostShutdownTimeout").text(dataConfig['boot.host_shutdown_timeout']); } else { $("#bootHostShutdownTimeout").text(""); }
           if (dataConfig.hasOwnProperty('boot.stop.priority')) { $("#bootStopPriority").text(dataConfig['boot.stop.priority']); } else { $("#bootStopPriority").text(""); }
+
+          if (dataConfig.hasOwnProperty('cloud-init.user-data')) { $("#cloudInitUserData").text(dataConfig['cloud-init.user-data']); } else { $("#cloudInitUserData").text(""); }
 
           if (dataConfig.hasOwnProperty('cluster.evacuate')) { $("#clusterEvacuate").text(dataConfig['cluster.evacuate']); } else { $("#clusterEvacuate").text(""); }
 

--- a/lxd-dashboard/containers.php
+++ b/lxd-dashboard/containers.php
@@ -514,6 +514,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <a class="nav-link" id="nav-nvidia-tab" data-toggle="tab" href="#nav-nvidia" role="tab" aria-controls="nav-nvidia" aria-selected="false">Nvidia</a>
                     <a class="nav-link" id="nav-other-tab" data-toggle="tab" href="#nav-other" role="tab" aria-controls="nav-other" aria-selected="false">Other</a>
                     <a class="nav-link" id="nav-raw-tab" data-toggle="tab" href="#nav-raw" role="tab" aria-controls="nav-raw" aria-selected="false">Raw</a>
+                    <a class="nav-link" id="nav-cloud-init-tab" data-toggle="tab" href="#nav-cloud-init" role="tab" aria-controls="nav-cloud-init" aria-selected="false">Cloud-Init</a>
                     <a class="nav-link" id="nav-security-tab" data-toggle="tab" href="#nav-security" role="tab" aria-controls="nav-security" aria-selected="false">Security</a>
                     <a class="nav-link" id="nav-snapshots-tab" data-toggle="tab" href="#nav-snapshots" role="tab" aria-controls="nav-snapshots" aria-selected="false">Snapshots</a>
                   </div>
@@ -916,6 +917,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       </div>
                     </div>
 
+                  </div>
+                  <div class="tab-pane fade" id="nav-cloud-init" role="tabpanel" aria-labelledby="nav-cloud-init">
+                    <div class="row">
+                      <label class="col-4 col-form-label text-right">User-Data: </label>
+                      <div class="col-6">
+                        <div class="form-group">
+			  <textarea id="containerCloudInitUserDataInput" class="form-control" name="containerCloudInitUserDataInput"></textarea>
+                        </div>
+                      </div>
+                      <div class="col-1">
+                        <i class="far fa-sm fa-question-circle" title="Enter the user-data configuration for cloud-init. Default: (not set)."></i>
+                      </div>
+                    </div>
                   </div>
                   <div class="tab-pane fade" id="nav-security" role="tabpanel" aria-labelledby="nav-security-tab">
                     <br>
@@ -1443,6 +1457,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     var bootHostShutdownTimeout = $("#containerBootHostShutdownTimeoutInput").val();
     var bootStopPriority = $("#containerBootStopPriorityInput").val();
 
+    var cloudInitUserData = $("#containerCloudInitUserDataInput").val();
+
     var limitsCpu = $("#containerLimitsCpuInput").val();
     var limitsCpuAllowance = $("#containerLimitsCpuAllowanceInput").val();
     var limitsCpuPriority = $("#containerLimitsCpuPriorityInput").val();
@@ -1515,6 +1531,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     "&boot_autostart_priority=" + encodeURI(bootAutostartPriority) + 
     "&boot_host_shutdown_timeout=" + encodeURI(bootHostShutdownTimeout) + 
     "&boot_stop_priority=" + encodeURI(bootStopPriority) + 
+
+    "&cloud_init_user_data=" + encodeURIComponent(cloudInitUserData) +
 
     "&limits_cpu=" + encodeURI(limitsCpu) + 
     "&limits_cpu_allowance=" + encodeURI(limitsCpuAllowance) + 


### PR DESCRIPTION
This patch allows user-data for cloud-init to be provided when defining an LXC container. Images containing cloud-init will use this data for initial provisioning. Once started, changes to cloud-init user-data usually doesn't make sense, therefore it is an option to just set once during the container creation. Feedback is welcome.