### PR TITLE
Cloud-init user-data is corrupted by urldecode()

### DIFF
--- a/lxd-dashboard/backend/lxd/containers.php
+++ b/lxd-dashboard/backend/lxd/containers.php
@@ -52,7 +52,7 @@ if (isset($_SESSION['username'])) {
   $boot_autostart_priority = (isset($_GET['boot_autostart_priority'])) ? filter_var(urldecode($_GET['boot_autostart_priority']), FILTER_SANITIZE_STRING) : "";
   $boot_host_shutdown_timeout = (isset($_GET['boot_host_shutdown_timeout'])) ? filter_var(urldecode($_GET['boot_host_shutdown_timeout']), FILTER_SANITIZE_STRING) : "";
   $boot_stop_priority = (isset($_GET['boot_stop_priority'])) ? filter_var(urldecode($_GET['boot_stop_priority']), FILTER_SANITIZE_STRING) : "";
-  $cloud_init_user_data = (isset($_GET['cloud_init_user_data'])) ? filter_var(urldecode($_GET['cloud_init_user_data']), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES) : "";
+  $cloud_init_user_data = (isset($_GET['cloud_init_user_data'])) ? filter_var($_GET['cloud_init_user_data'], FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES) : "";
   $limits_cpu = (isset($_GET['limits_cpu'])) ? filter_var(urldecode($_GET['limits_cpu']), FILTER_SANITIZE_STRING) : "";
   $limits_cpu_allowance = (isset($_GET['limits_cpu_allowance'])) ? filter_var(urldecode($_GET['limits_cpu_allowance']), FILTER_SANITIZE_STRING) : "";
   $limits_cpu_priority = (isset($_GET['limits_cpu_priority'])) ? filter_var(urldecode($_GET['limits_cpu_priority']), FILTER_SANITIZE_STRING) : "";


### PR DESCRIPTION
Thanks for merging #44 ! Unfortunately, I've overseen one issue: urldecode() turns '+' into ' ', which breaks SSH keys. Removing urldecode() fixes this, however, it would probably be better to generally use POST requests whenever resources are added or patched. I will open a dedicated issue for this topic.